### PR TITLE
Fixed project import, export and added dependency to commander

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2021.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "commander": "^8.3.0",
         "formdata-node": "^6.0.3",
         "https-proxy-agent": "^7.0.4",
         "log4js": "^6.9.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "commander": "^8.3.0"
   },
   "dependencies": {
+    "commander": "^8.3.0",
     "formdata-node": "^6.0.3",
     "https-proxy-agent": "^7.0.4",
     "log4js": "^6.9.1",

--- a/wmiocli.js
+++ b/wmiocli.js
@@ -425,12 +425,21 @@ program.command('project-triggers-delete <project-id> <trigger-id>')
 
 
 
-  program.command('project-export <project-id>')
+  program.command('project-export <project-id> <filename>')
   .description('Exports a project')
-  .action((projectId) => {
+  .action((projectId, filename) => {
     checkOptions();
     project.init(tenantDomain, tenantUser, tenantPw, program.opts().timeout, program.opts().prettyprint)
-    project.exportProj(projectId);
+    project.exportProj(projectId, filename);
+  });
+
+  
+  program.command('project-import <filename> <projectname>')
+  .description('Imports a project')
+  .action((filename, projectname) => {
+    checkOptions();
+    project.init(tenantDomain, tenantUser, tenantPw, program.opts().timeout, program.opts().prettyprint)
+    project.importProj(filename, projectname);
   });
 
 /**


### PR DESCRIPTION
Fixed project ex and import commands. Please consider adding the dependency to commander. This should make it easier to use the wmiocli by just calling:

npm install git+https://github.com/MarcFriedhoff/webmethods-io-integration-apicli.git

This should then work without additional git checkout:

node ./node_modules/.bin/wmiocli

